### PR TITLE
Fix e2e test by providing entry_date

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -31,6 +31,7 @@ class TestKittySplitAPIE2E(unittest.TestCase):
         api.add_expense(
             amount="10.00",
             description=self.test_expense_description,
+            entry_date="2024-03-28",
         )
 
         # find the expense we just added in the list of expenses


### PR DESCRIPTION
This pull request fixes an e2e test by adding the entry_date parameter to the add_expense function. This ensures that the test accurately reflects the expected behavior of the code.